### PR TITLE
Add Windows build script to avoid SmartScreen warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,31 @@ Currently only supported on **Windows**
 - Access configuration options via a convenient system tray menu:
     - Adjust overlay opacity to suit your preferences.
     - Enable or disable system notifications when the keyboard is locked.
-## Build an executable
-```bash
-pip install pyinstaller
+## Installation
+
+### Option 1: Build Locally (Recommended)
+
+Building locally avoids Windows SmartScreen warnings that can block downloaded executables.
+
+**Easy method** - Just run the build script:
+```
+build.bat
 ```
 
+**Manual method:**
 ```bash
-pyinstaller --onefile --add-data="./resources/img/icon.ico:./resources/img/" --add-data="./resources/img/icon.png:./resources/img/" --add-data="./resources/config/config.json:./resources/config/" --icon="./resources/img/icon.ico" --hidden-import plyer.platforms.win.notification --noconsole --name="CatLock" "./src/main.py"
+pip install -r requirements.txt
+pip install pyinstaller
+pyinstaller --onefile --add-data="./resources/img/icon.ico;./resources/img/" --add-data="./resources/img/icon.png;./resources/img/" --add-data="./resources/config/config.json;./resources/config/" --icon="./resources/img/icon.ico" --hidden-import plyer.platforms.win.notification --noconsole --name="CatLock" "./src/main.py"
 ```
+
+The executable will be in the `dist/` folder.
+
+> **Note:** If Windows Defender flags your locally-built exe, add the `dist` folder to Windows Security exclusions.
+
+### Option 2: Download Pre-built Release
+
+Pre-built executables are available on the [Releases](../../releases) page. Note that Windows SmartScreen may warn about unsigned executables from the internet.
 ## Caveats
 - Relies on https://github.com/boppreh/keyboard/ which only has full support for Windows
 - OS bound hotkeys take precedence such as `ctrl+alt+del` (this way you don't get locked out if something goes wrong)

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,65 @@
+@echo off
+REM CatLock Build Script for Windows
+REM This script builds a local executable that won't be blocked by SmartScreen
+
+echo ========================================
+echo CatLock Build Script
+echo ========================================
+echo.
+
+REM Check if Python is installed
+python --version >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Python is not installed or not in PATH
+    echo Please install Python from https://www.python.org/downloads/
+    pause
+    exit /b 1
+)
+
+echo [1/3] Installing dependencies...
+pip install -r requirements.txt
+if errorlevel 1 (
+    echo ERROR: Failed to install dependencies
+    pause
+    exit /b 1
+)
+
+echo.
+echo [2/3] Installing PyInstaller...
+pip install pyinstaller
+if errorlevel 1 (
+    echo ERROR: Failed to install PyInstaller
+    pause
+    exit /b 1
+)
+
+echo.
+echo [3/3] Building CatLock executable...
+pyinstaller --onefile ^
+    --add-data="./resources/img/icon.ico;./resources/img/" ^
+    --add-data="./resources/img/icon.png;./resources/img/" ^
+    --add-data="./resources/config/config.json;./resources/config/" ^
+    --icon="./resources/img/icon.ico" ^
+    --hidden-import plyer.platforms.win.notification ^
+    --noconsole ^
+    --name="CatLock" ^
+    "./src/main.py"
+
+if errorlevel 1 (
+    echo ERROR: Build failed
+    pause
+    exit /b 1
+)
+
+echo.
+echo ========================================
+echo BUILD SUCCESSFUL!
+echo ========================================
+echo.
+echo Your executable is located at:
+echo   dist\CatLock.exe
+echo.
+echo TIP: If Windows Defender flags it, add the dist folder
+echo      to your exclusions list in Windows Security.
+echo.
+pause


### PR DESCRIPTION
- Add build.bat for easy local building on Windows
- Update README with clearer installation instructions
- Building locally avoids SmartScreen blocking unsigned executables